### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for working with Building Information Modeling (BIM) files. This server provides tools to convert IFC files to fragment format, load fragments, and query BIM data by category.
 
+<a href="https://glama.ai/mcp/servers/@helenkwok/openbim-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@helenkwok/openbim-mcp/badge" alt="Fragment Server MCP server" />
+</a>
+
 ## Features
 
 - **IFC to Fragment Conversion**: Convert Industry Foundation Classes (IFC) files to the open and  efficient fragment format


### PR DESCRIPTION
This PR adds a badge for the [Fragment MCP Server](https://glama.ai/mcp/servers/@helenkwok/openbim-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@helenkwok/openbim-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@helenkwok/openbim-mcp/badge" alt="Fragment Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.